### PR TITLE
Renamed core find_trigger_urls method

### DIFF
--- a/bin/trigfind
+++ b/bin/trigfind
@@ -97,7 +97,7 @@ if trigfind.daily_cbc.match(args.etg):
 
 cache = Cache()
 for seg in segs:
-    cache.extend(trigfind.find_trigger_urls(
+    cache.extend(trigfind.find_trigger_files(
         args.channel, args.etg, start, end, **kwargs))
 
 # find gaps

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -52,6 +52,7 @@ help:
 .PHONY: clean
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf api/*
 
 .PHONY: html
 html: autogen

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ For a full listing of all arguments and options, run:
 
    $ trigfind --help
 
-`~trigfind.find_trigger_urls`
+`~trigfind.find_trigger_files`
 -----------------------------
 
 The ``trigfind`` module provides a convience function to find files for any Event Trigger Generator:
@@ -46,12 +46,12 @@ The ``trigfind`` module provides a convience function to find files for any Even
 .. autosummary::
    :toctree: api/
 
-   trigfind.find_trigger_urls
+   trigfind.find_trigger_files
 
 ::
 
-   >>> from trigfind import find_trigger_urls
-   >>> files = find_trigger_urls('L1:GDS-CALIB_STRAIN', 'omicron', 1135641617, 1135728017)
+   >>> from trigfind import find_trigger_files
+   >>> files = find_trigger_files('L1:GDS-CALIB_STRAIN', 'omicron', 1135641617, 1135728017)
 
 The above method passes information along to one of the following that actually finds the files for a given Event Trigger Generator:
 

--- a/trigfind/core.py
+++ b/trigfind/core.py
@@ -25,6 +25,7 @@ import glob
 import os.path
 import re
 import datetime
+import warnings
 
 from glue.lal import (Cache, CacheEntry)
 from glue.segments import segment as Segment
@@ -40,7 +41,7 @@ channel_delim = re.compile('[:_-]')
 OMICRON_O2_EPOCH = 1146873617
 
 
-def find_trigger_urls(channel, etg, start, end, **kwargs):
+def find_trigger_files(channel, etg, start, end, **kwargs):
     """Find the paths of trigger files for this channel and ETG
 
     This method uses an ETG-specific finder function to retrieve the
@@ -77,8 +78,8 @@ def find_trigger_urls(channel, etg, start, end, **kwargs):
 
     Examples
     --------
-    >>> from trigfind import find_trigger_urls
-    >>> cache = find_trigger_urls('L1:GDS-CALIB_STRAIN', 'Omicron', 1135641617, 1135728017)
+    >>> from trigfind import find_trigger_files
+    >>> cache = find_trigger_files('L1:GDS-CALIB_STRAIN', 'Omicron', 1135641617, 1135728017)
     """
     start = int(start)
     end = int(end)
@@ -95,6 +96,14 @@ def find_trigger_urls(channel, etg, start, end, **kwargs):
         finder = find_detchar_files
         kwargs['etg'] = etg
     return finder(channel, start, end, **kwargs)
+
+
+def find_trigger_urls(*args, **kwargs):
+    warnings.warn("this method was renamed find_trigger_files",
+                  DeprecationWarning)
+    return find_trigger_files(*args, **kwargs)
+
+find_trigger_urls.__doc__ = find_trigger_files.__doc__
 
 
 def find_detchar_files(channel, start, end, etg='omicron', ext='xml.gz'):


### PR DESCRIPTION
This PR renames the central function `find_trigger_urls` to `find_trigger_files`. This is mainly because all of the other methods use `_files` and it makes more sense since we're only serving local data.

This does provide a shell for `find_trigger_urls` that presents a `DeprecationWarning` then calls `find_trigger_files`.
