### PR TITLE
Use mock to allow testing of file finders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 
 before_install:
   - pip install -q --upgrade ${PRE} pip
-  - pip install -q --upgrade ${PRE} coveralls "pytest>=2.8" unittest2
+  - pip install -q --upgrade ${PRE} coveralls "pytest>=2.8" unittest2 mock
 
 install:
   - pip install ${PRE} -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ install:
   - pip install .
 
 script:
-  - coverage run --source=trigfind --omit="trigfind/tests/*,trigfind/_version.py" ./setup.py test
-  - coverage run --append --source=trigfind --omit="trigfind/tests/*,trigfind/_version.py" `which trigfind` --help
+  - coverage run --source=trigfind --omit="trigfind/_version.py" ./setup.py test
+  - coverage run --append --source=trigfind --omit="trigfind/_version.py" `which trigfind` --help
 
 after_success:
   - coveralls

--- a/test_trigfind.py
+++ b/test_trigfind.py
@@ -154,9 +154,12 @@ class TrigfindTestCase(unittest.TestCase):
 
     def test_find_daily_cbc_files(self):
         # can't do much without faking the entire thing
-        cache = trigfind.find_daily_cbc_files('L1:GDS-CALIB_STRAIN',
-                                              0, 100)
-        self.assertIsInstance(cache, Cache)
+        try:
+            cache = trigfind.find_daily_cbc_files('L1:GDS-CALIB_STRAIN', 0, 100)
+        except ImportError as e:
+            self.skipTest(str(e))
+        else:
+            self.assertIsInstance(cache, Cache)
 
     def test_find_omega_online_files(self):
         finder = mock_finder('G1-OMEGA_TRIGGERS_DOWNSELECT-{0}-{1}.txt')

--- a/trigfind/core.py
+++ b/trigfind/core.py
@@ -190,6 +190,10 @@ def find_dmt_files(channel, start, end, base=None, etg='kw', ext='xml'):
     files : :class:`~glue.lal.Cache`
         a structured list of file URLS
     """
+    # validate ETG is sensible
+    if not kleinewelle.match(etg) and not dmt_omega.match(etg):
+        raise NotImplementedError("Unrecognised ETG %r for DMT files")
+
     span = Segment(int(start), int(end))
     ifo, name = _format_channel_name(str(channel)).split('-', 1)
     hoft = name == 'GDS_CALIB_STRAIN'


### PR DESCRIPTION
This PR introduces better unit tests of each of the ETG finder methods, using `mock` to fake the `_find_in_gps_dirs` step that would require the files to actually exist.
