### PR TITLE
add test version of function to locate pycbc live files

### DIFF
--- a/test_trigfind.py
+++ b/test_trigfind.py
@@ -178,12 +178,20 @@ class TrigfindTestCase(unittest.TestCase):
                           'X1:DOES-NOT_EXIST:1', 0, 100, etg='fake-etg')
 
     def test_find_pycbc_live_files(self):
-        try:
-            cache = trigfind.find_pycbc_live_files(None, 0, 100)
-        except ImportError as e:
-            self.skipTest(str(e))
-        else:
-            self.assertIsInstance(cache, Cache)
+        test_glob = ['H1-Live-1126259148.29-4.hdf',
+                     'H1-Live-1126259228.29-4.hdf', 
+                     'H1-Live-1126259308.29-4.hdf',
+                     'H1-Live-1126259388.29-4.hdf',
+                    ]
+
+        # outside times, so no return expected
+        with mock.patch('glob.glob', lambda x: test_glob):
+            c = trigfind.find_pycbc_live_files(None, 1135641617, 1135728017)
+            self.assertIsInstance(c, Cache)
+            self.assertEqual(len(c), 0)
+
+            c = trigfind.find_pycbc_live_files(None, 1126259140, 1126269148)
+            self.assertEqual(len(c), 4)
 
     def test_find_daily_cbc_files(self):
         # can't do much without faking the entire thing

--- a/test_trigfind.py
+++ b/test_trigfind.py
@@ -185,14 +185,17 @@ class TrigfindTestCase(unittest.TestCase):
                     ]
 
         # outside times, so no return expected
-        with mock.patch('glob.glob', lambda x: test_glob):
-            c = trigfind.find_pycbc_live_files(None, 1135641617, 1135728017)
-            self.assertIsInstance(c, Cache)
-            self.assertEqual(len(c), 0)
+        try:
+            with mock.patch('glob.glob', lambda x: test_glob):
+                c = trigfind.find_pycbc_live_files(None, 1135641617, 1135728017)
+                self.assertIsInstance(c, Cache)
+                self.assertEqual(len(c), 0)
 
-            c = trigfind.find_pycbc_live_files(None, 1126259140, 1126269148)
-            self.assertEqual(len(c), 4)
-
+                c = trigfind.find_pycbc_live_files(None, 1126259140, 1126269148)
+                self.assertEqual(len(c), 4)
+        except ImportError as e:
+            self.skipTest(str(e))
+            
     def test_find_daily_cbc_files(self):
         # can't do much without faking the entire thing
         try:

--- a/test_trigfind.py
+++ b/test_trigfind.py
@@ -179,7 +179,7 @@ class TrigfindTestCase(unittest.TestCase):
 
     def test_find_pycbc_live_files(self):
         try:
-            cache = trigfind.find_pycbc_live_cbc_files(None, 0, 100)
+            cache = trigfind.find_pycbc_live_files(None, 0, 100)
         except ImportError as e:
             self.skipTest(str(e))
         else:

--- a/test_trigfind.py
+++ b/test_trigfind.py
@@ -177,6 +177,14 @@ class TrigfindTestCase(unittest.TestCase):
         self.assertRaises(ValueError, trigfind.find_detchar_files,
                           'X1:DOES-NOT_EXIST:1', 0, 100, etg='fake-etg')
 
+    def test_find_pycbc_live_files(self):
+        try:
+            cache = trigfind.find_pycbc_live_cbc_files(None, 0, 100)
+        except ImportError as e:
+            self.skipTest(str(e))
+        else:
+            self.assertIsInstance(cache, Cache)
+
     def test_find_daily_cbc_files(self):
         # can't do much without faking the entire thing
         try:

--- a/test_trigfind.py
+++ b/test_trigfind.py
@@ -179,7 +179,7 @@ class TrigfindTestCase(unittest.TestCase):
 
     def test_find_pycbc_live_files(self):
         test_glob = ['H1-Live-1126259148.29-4.hdf',
-                     'H1-Live-1126259228.29-4.hdf', 
+                     'H1-Live-1126259228.29-4.hdf',
                      'H1-Live-1126259308.29-4.hdf',
                      'H1-Live-1126259388.29-4.hdf',
                     ]

--- a/trigfind/core.py
+++ b/trigfind/core.py
@@ -295,13 +295,12 @@ def find_pycbc_live_files(channel, start, end, run='official'):
                 continue
 
             url = os.path.abspath(file)
-            cache.append(CacheEntry("%s %s %s %s %s" % (ifos, name, 
+            cache.append(CacheEntry("%s %s %s %s %s" % (ifos, name,
                                                         fstart,
                                                         dur, url)))
         date += oneday
     return cache
 
-    
 
 def find_daily_cbc_files(channel, start, end, run='bns_gds',
                          filetag='30MILLISEC_CLUSTERED', ext='xml.gz'):


### PR DESCRIPTION
This adds a function to find pycbc live files. It will only work currently for the files available for testing purposes. (which only cover 9/14/15 - 9/16/15). I'm working on getting a shared account for this data, so the basename string will need to be updated when that happens. 
