### PR TITLE
Fixed corner-case bug in searching 5-digit GPS directories

### DIFF
--- a/trigfind/core.py
+++ b/trigfind/core.py
@@ -227,7 +227,7 @@ def find_dmt_files(channel, start, end, base=None, etg='kw', ext='xml'):
 def _find_in_gps_dirs(globpath, start, end, ngps=5):
     span = Segment(start, end)
     form = '%%.%ss' % ngps
-    gps5 = int(form % start)
+    gps5 = max(0, int(form % start) - 1)
     end5 = int(form % end)
     out = Cache()
     append = out.append


### PR DESCRIPTION
This PR modifies the `_find_in_gps5_dirs` method to start searching one 5-digit GPS directory early, allowing for files that run into the starting GPS-5 directory to be returned.
