### PR TITLE
Updated dependencies for lscsoft-glue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+sudo: false
+dist: trusty
+
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ addons:
     packages:
       - swig  # m2crypto
 
+env:
+  global:
+    - LAL_VERSION="6.18.0"
+
 matrix:
   include:
-    - python: 2.6
     - python: 2.7
     - python: 3.5
     - python: nightly
@@ -20,6 +23,8 @@ matrix:
 before_install:
   - pip install -q --upgrade ${PRE} pip
   - pip install -q --upgrade ${PRE} coveralls "pytest>=2.8" unittest2 mock
+  - pip install -q --upgrade ${PRE} numpy  # for lal
+  - .travis/build-lal.sh
 
 install:
   - pip install ${PRE} -r requirements.txt
@@ -33,5 +38,7 @@ after_success:
   - coveralls
 
 cache:
-  - pip
-  - apt
+  apt: true
+  pip: true
+  directories:
+    - lal-${LAL_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,7 @@ cache:
   pip: true
   directories:
     - lal-${LAL_VERSION}
+
+before_cache:
+  - rm -f ${HOME}/.cache/pip/log/debug.log
+  - rm -f ./lal-${LAL_VERSION}/config.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@ language: python
 addons:
   apt:
     packages:
-      - swig  # m2crypto
+      - pkg-config  # lal
+      - zlib1g-dev  # lal
+      - libgsl0-dev  # lal
+      - swig  # lal
+      - bc  # lal
+      - libfftw3-dev  # lal
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: python
 
 addons:
   apt:
+    sources:
+      - sourceline: deb http://software.ligo.org/lscsoft/debian wheezy contrib
+        key_url: http://software.ligo.org/keys/deb/lscsoft.key
+      - sourceline: deb-src http://software.ligo.org/lscsoft/debian wheezy contrib
+        key_url: http://software.ligo.org/keys/deb/lscsoft.key
     packages:
       - pkg-config  # lal
       - zlib1g-dev  # lal

--- a/.travis/build-lal.sh
+++ b/.travis/build-lal.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+set -x
+
+LAL_TAG="lal-${LAL_VERSION}"
+LAL_TARBALL="${LAL_TAG}.tar.xz"
+LAL_SOURCE="http://software.ligo.org/lscsoft/source/lalsuite"
+
+target=`python -c "import sys; print(sys.prefix)"`
+
+echo "----------------------------------------------------------------------"
+echo "Installing from ${LAL_TARBALL}"
+
+wget ${LAL_SOURCE}/${LAL_TARBALL} -O ${LAL_TARBALL} --quiet
+mkdir -p ${LAL_TAG}
+tar -xf ${LAL_TARBALL} --strip-components=1 -C ${LAL_TAG}
+cd ${LAL_TAG}
+./configure --enable-silent-rules --enable-swig-python --quiet --prefix=${target}
+make --silent
+make install --silent

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 lscsoft-glue>=1.56
+python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-pykerberos
-m2crypto
-python-cjson
-http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
+lscsoft-glue>=1.56

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ scripts = glob.glob(os.path.join('bin', '*'))
 
 # declare dependencies
 setup_requires = ['setuptools', 'pytest-runner']
+install_requires = ['lscsoft-glue>=1.56']
 requires = ['glue']
 tests_require = ['pytest']
 if sys.version_info < (2, 7):
@@ -51,12 +52,9 @@ setup(name='trigfind',
       packages=packages,
       scripts=scripts,
       setup_requires=setup_requires,
+      install_requires=install_requires,
       requires=requires,
       tests_require=tests_require,
-      dependency_links=[
-          'http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz'
-          '#egg=glue-1.49.1',
-      ],
       use_2to3=False,
       classifiers=[
           'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ scripts = glob.glob(os.path.join('bin', '*'))
 
 # declare dependencies
 setup_requires = ['setuptools', 'pytest-runner']
-install_requires = ['lscsoft-glue>=1.56']
-requires = ['glue']
+install_requires = ['lscsoft-glue>=1.56', 'python-dateutil']
+requires = ['glue', 'dateutil']
 tests_require = ['pytest']
 if sys.version_info < (2, 7):
     tests_require.append('unittest2')


### PR DESCRIPTION
This PR updates the dependencies for `trigfind` to reference the pypi-registered version of glue `lscsoft-glue`.