### PR TITLE
Separated DMT ETG finder methods

### DIFF
--- a/test_trigfind.py
+++ b/test_trigfind.py
@@ -69,7 +69,6 @@ def mock_iglob_factory(fileformat):
         t = gpsstart
         while t < gpsend:
             f = os.path.join(parent, fileformat.format(t, d))
-            print(f)
             t += d
             yield f
     return mock_gps_glob
@@ -123,6 +122,10 @@ class TrigfindTestCase(unittest.TestCase):
                 cache[0].path,
                 '/gds-l1/dmt/triggers/L-HOFT_Omega/11356/'
                 'L1-OMEGA_TRIGGERS_DOWNSELECT-1135640000-10000.xml')
+            # check wrapper method works
+            self.assertListEqual(cache, trigfind.find_trigger_files(
+                'L1:GDS-CALIB_STRAIN', 'dmt-omega', 1135641617, 1135728017))
+
         # check error for non-hoft channel with DMT-Omega
         self.assertRaises(NotImplementedError, trigfind.find_dmt_omega_files,
                           'X1:TEST', 0, 100)
@@ -138,6 +141,10 @@ class TrigfindTestCase(unittest.TestCase):
                              '/gds-l1/dmt/triggers/L-KW_TRIGGERS/'
                              'L-KW_TRIGGERS-11356/'
                              'L-KW_TRIGGERS-1135640000-10000.xml')
+            # check wrapper method works
+            self.assertListEqual(cache, trigfind.find_trigger_files(
+                'L1:TEST-CHANNEL', 'kleinewelle', 1135641617, 1135728017))
+
         # test h(t)
         iglob = mock_iglob_factory('L-KW_HOFT-{0}-{1}.xml')
         with mock.patch('glob.iglob', iglob):
@@ -163,13 +170,18 @@ class TrigfindTestCase(unittest.TestCase):
                     cache[0].path,
                     '/home/detchar/triggers/*/L1/GDS-CALIB_STRAIN_Omicron/'
                     '11356/L1-GDS_CALIB_STRAIN_OMICRON-1135640000-10000.xml')
-                cache = trigfind.find_detchar_files(
+                cache2 = trigfind.find_detchar_files(
                     'L1:GDS-CALIB_STRAIN', 1146873617, 1146873617+1,
                     etg='omicron')
                 self.assertEqual(
-                    cache[0].path,
+                    cache2[0].path,
                     '/home/detchar/triggers/L1/GDS_CALIB_STRAIN_OMICRON/11468/'
                     'L1-GDS_CALIB_STRAIN_OMICRON-1146870000-10000.xml')
+
+                # check wrapper method works
+                self.assertListEqual(cache, trigfind.find_trigger_files(
+                    'L1:GDS-CALIB_STRAIN', 'omicron', 1135641617, 1135728017))
+
         # test error for channel that has never been processed
         self.assertRaises(ValueError, trigfind.find_detchar_files,
                           'X1:DOES-NOT_EXIST:1', 0, 100, etg='fake-etg')
@@ -190,9 +202,14 @@ class TrigfindTestCase(unittest.TestCase):
 
                 c = trigfind.find_pycbc_live_files(None, 1126259140, 1126269148)
                 self.assertEqual(len(c), 4)
+
+                # check wrapper method works
+                self.assertListEqual(c, trigfind.find_trigger_files(
+                    None, 'pycbc-live', 1126259140, 1126269148))
+
         except ImportError as e:
             self.skipTest(str(e))
-            
+
     def test_find_daily_cbc_files(self):
         # can't do much without faking the entire thing
         try:
@@ -201,6 +218,8 @@ class TrigfindTestCase(unittest.TestCase):
             self.skipTest(str(e))
         else:
             self.assertIsInstance(cache, Cache)
+            self.assertListEqual(cache, trigfind.find_trigger_files(
+                'L1:GDS-CALIB_STRAIN', 'daily-cbc', 0, 100))
 
     def test_find_omega_online_files(self):
         iglob = mock_iglob_factory('G1-OMEGA_TRIGGERS_DOWNSELECT-{0}-{1}.txt')
@@ -213,6 +232,11 @@ class TrigfindTestCase(unittest.TestCase):
                 cache[0].path,
                 '/home/omega/online/G1_DER_DATA_H/segments/11356/*/'
                 'G1-OMEGA_TRIGGERS_DOWNSELECT-1135640000-10000.txt')
+
+            # check wrapper method works
+            self.assertListEqual(cache, trigfind.find_trigger_files(
+                'G1:DER_DATA_H', 'omega', 1135641617, 1135728017))
+
         self.assertRaises(NotImplementedError,
                           trigfind.find_omega_online_files, 'L1:TEST-CHANNEL',
                           0, 100)

--- a/test_trigfind.py
+++ b/test_trigfind.py
@@ -101,40 +101,37 @@ class TrigfindTestCase(unittest.TestCase):
 
     def test_find_trigger_files(self):
         # quick check that this resolves the ETG correctly
-        iglob = mock_iglob_factory('L1-GDS_CALIB_STRAIN_OmegaC-{0}-{1}.xml')
+        iglob = mock_iglob_factory('L1-OMEGA_TRIGGERS_DOWNSELECT-{0}-{1}.xml')
         with mock.patch('glob.iglob', iglob):
             cache = trigfind.find_trigger_files(
                 'L1:GDS-CALIB_STRAIN', 'dmt-omega', 1135641617, 1135728017)
             self.assertIsInstance(cache, Cache)
             self.assertEqual(len(cache), 9)
-            self.assertEqual(cache[0].path,
-                             '/gds-l1/dmt/triggers/L-HOFT_Omega/11356/'
-                             'L1-GDS_CALIB_STRAIN_OmegaC-1135640000-10000.xml')
+            self.assertEqual(
+                cache[0].path,
+                '/gds-l1/dmt/triggers/L-HOFT_Omega/11356/'
+                'L1-OMEGA_TRIGGERS_DOWNSELECT-1135640000-10000.xml')
 
-    def test_find_dmt_files(self):
-        # check error for unknown ETG
-        self.assertRaises(NotImplementedError, trigfind.find_dmt_files,
-                          None, 0, 100, etg='fake-etg')
-
-    def test_find_dmt_files_dmt_omega(self):
-        iglob = mock_iglob_factory('L1-GDS_CALIB_STRAIN_OmegaC-{0}-{1}.xml')
+    def test_find_dmt_omega_files(self):
+        iglob = mock_iglob_factory('L1-OMEGA_TRIGGERS_DOWNSELECT-{0}-{1}.xml')
         with mock.patch('glob.iglob', iglob):
-            cache = trigfind.find_dmt_files(
-                'L1:GDS-CALIB_STRAIN', 1135641617, 1135728017, etg='dmt-omega')
+            cache = trigfind.find_dmt_omega_files(
+                'L1:GDS-CALIB_STRAIN', 1135641617, 1135728017)
             self.assertIsInstance(cache, Cache)
             self.assertEqual(len(cache), 9)
-            self.assertEqual(cache[0].path,
-                             '/gds-l1/dmt/triggers/L-HOFT_Omega/11356/'
-                             'L1-GDS_CALIB_STRAIN_OmegaC-1135640000-10000.xml')
+            self.assertEqual(
+                cache[0].path,
+                '/gds-l1/dmt/triggers/L-HOFT_Omega/11356/'
+                'L1-OMEGA_TRIGGERS_DOWNSELECT-1135640000-10000.xml')
         # check error for non-hoft channel with DMT-Omega
-        self.assertRaises(NotImplementedError, trigfind.find_dmt_files,
-                          'X1:TEST', 0, 100, etg='dmt-omega')
+        self.assertRaises(NotImplementedError, trigfind.find_dmt_omega_files,
+                          'X1:TEST', 0, 100)
 
-    def test_find_dmt_files_kleinewelle(self):
+    def test_find_kleinewelle_files(self):
         iglob = mock_iglob_factory('L-KW_TRIGGERS-{0}-{1}.xml')
         with mock.patch('glob.iglob', iglob):
-            cache = trigfind.find_dmt_files('L1:TEST-CHANNEL', 1135641617,
-                                            1135728017, etg='kleinewelle')
+            cache = trigfind.find_kleinewelle_files(
+                'L1:TEST-CHANNEL', 1135641617, 1135728017)
             self.assertIsInstance(cache, Cache)
             self.assertEqual(len(cache), 9)
             self.assertEqual(cache[0].path,
@@ -144,8 +141,8 @@ class TrigfindTestCase(unittest.TestCase):
         # test h(t)
         iglob = mock_iglob_factory('L-KW_HOFT-{0}-{1}.xml')
         with mock.patch('glob.iglob', iglob):
-            cache = trigfind.find_dmt_files('L1:GDS-CALIB_STRAIN', 1135641617,
-                                            1135728017, etg='kleinewelle')
+            cache = trigfind.find_kleinewelle_files(
+                'L1:GDS-CALIB_STRAIN', 1135641617, 1135728017)
             self.assertIsInstance(cache, Cache)
             self.assertEqual(len(cache), 9)
             self.assertEqual(cache[0].path,

--- a/trigfind/core.py
+++ b/trigfind/core.py
@@ -77,7 +77,8 @@ def find_trigger_files(channel, etg, start, end, **kwargs):
     --------
     trigfind.find_detchar_files
     trigfind.find_daily_cbc_files
-    trigfind.find_dmt_files
+    trigfind.find_dmt_omega_files
+    trigfind.find_kleinewelle_files
     trigfind.find_omega_online_files
 
     Examples
@@ -95,9 +96,10 @@ def find_trigger_files(channel, etg, start, end, **kwargs):
         finder = find_pycbc_live_files
     elif omega.match(etg):
         finder = find_omega_online_files
-    elif kleinewelle.match(etg) or dmt_omega.match(etg):
-        finder = find_dmt_files
-        kwargs['etg'] = etg
+    elif kleinewelle.match(etg):
+        finder = find_kleinewelle_files
+    elif dmt_omega.match(etg):
+        finder = find_dmt_omega_files
     else:
         finder = find_detchar_files
         kwargs['etg'] = etg
@@ -166,7 +168,52 @@ def find_detchar_files(channel, start, end, etg='omicron', ext='xml.gz'):
                              start, end, ngps=5)
 
 
-def find_dmt_files(channel, start, end, base=None, etg='kw', ext='xml'):
+def find_kleinewelle_files(channel, start, end, base=None, ext='xml'):
+    """Find KleineWelle output event files
+
+    Parameters
+    ----------
+    channel : `str`
+        name of data channel for which to search
+
+    start : `int`
+        GPS start time of search
+
+    end : `int`
+        GPS end time of search
+
+    base : `str, optional
+        path of custom base directory, defaults to the LDG standard for
+        the given ``etg``
+
+    ext : `str`, optional
+        file extension, defaults to ``'xml'``
+
+    Returns
+    -------
+    files : :class:`~glue.lal.Cache`
+        a structured list of file URLS
+    """
+    span = Segment(int(start), int(end))
+    ifo, name = _format_channel_name(str(channel)).split('-', 1)
+    hoft = name == 'GDS_CALIB_STRAIN'
+    site = ifo[0].upper()
+
+    # find base path
+    if hoft:
+        tag = '%s-KW_HOFT' % site
+    else:
+        tag = '%s-KW_TRIGGERS' % site
+    if base is None:
+        base = os.path.join(os.sep, 'gds-{}'.format(ifo.lower()),
+                            'dmt', 'triggers', tag, '{}-{{0}}'.format(tag))
+
+    # loop over GPS directories and find files
+    filename = '%s-*-*.%s' % (tag, ext)
+    return _find_in_gps_dirs(os.path.join(base, filename), start, end, ngps=5)
+
+
+def find_dmt_omega_files(channel, start, end, base=None, ext='xml'):
     """Find DMT-Omega trigger XML files
 
     Parameters
@@ -184,10 +231,6 @@ def find_dmt_files(channel, start, end, base=None, etg='kw', ext='xml'):
         path of custom base directory, defaults to the LDG standard for
         the given ``etg``
 
-    etg : `str`, optional
-        name of trigger generator that processed the data, defaults to
-        ``'kw'``
-
     ext : `str`, optional
         file extension, defaults to ``'xml'``
 
@@ -196,34 +239,23 @@ def find_dmt_files(channel, start, end, base=None, etg='kw', ext='xml'):
     files : :class:`~glue.lal.Cache`
         a structured list of file URLS
     """
-    # validate ETG is sensible
-    if not kleinewelle.match(etg) and not dmt_omega.match(etg):
-        raise NotImplementedError("Unrecognised ETG %r for DMT files")
-
     span = Segment(int(start), int(end))
     ifo, name = _format_channel_name(str(channel)).split('-', 1)
     hoft = name == 'GDS_CALIB_STRAIN'
-    # find base path
     site = ifo[0].upper()
-    if base is None and kleinewelle.match(etg):
-        if hoft:
-            tag = '%s-KW_HOFT' % site
-        else:
-            tag = '%s-KW_TRIGGERS' % site
-        base = '/gds-%s/dmt/triggers/%s/%s-{0}' % (ifo.lower(), tag, tag)
-    elif base is None and dmt_omega.match(etg):
-        if hoft:
-            tag = '%s-HOFT_Omega' % site
-        else:
-            raise NotImplementedError("This method doesn't know how to locate "
-                                      "%s files for %r" % (etg, str(channel)))
-        base = '/gds-%s/dmt/triggers/%s/{0}' % (ifo.lower(), tag)
-    # find file name format
-    if dmt_omega.match(etg):
-        filename = '%s-%s_OmegaC-*-*.%s' % (ifo, name, ext)
+
+    # find base path
+    if hoft:
+        tag = '{}-HOFT_Omega'.format(site)
     else:
-        filename = '%s-*-*.%s' % (tag, ext)
+        raise NotImplementedError("This method doesn't know how to locate "
+                                  "%s files for %r" % (etg, str(channel)))
+    if base is None:
+        base = os.path.join(os.sep, 'gds-{}'.format(ifo.lower()), 'dmt',
+                            'triggers', tag, '{0}')
+
     # loop over GPS directories and find files
+    filename = '{}-OMEGA_TRIGGERS_DOWNSELECT-*.{}'.format(ifo, ext)
     return _find_in_gps_dirs(os.path.join(base, filename), start, end, ngps=5)
 
 

--- a/trigfind/core.py
+++ b/trigfind/core.py
@@ -256,7 +256,7 @@ def find_dmt_omega_files(channel, start, end, base=None, ext='xml'):
                             'triggers', tag, '{0}')
 
     # loop over GPS directories and find files
-    filename = '{}-OMEGA_TRIGGERS_DOWNSELECT-*.{}'.format(ifo, ext)
+    filename = '{}-{}_OmegaC-*-*.{}'.format(ifo, name, ext)
     return _find_in_gps_dirs(os.path.join(base, filename), start, end, ngps=5)
 
 

--- a/trigfind/core.py
+++ b/trigfind/core.py
@@ -248,8 +248,9 @@ def find_dmt_omega_files(channel, start, end, base=None, ext='xml'):
     if hoft:
         tag = '{}-HOFT_Omega'.format(site)
     else:
-        raise NotImplementedError("This method doesn't know how to locate "
-                                  "%s files for %r" % (etg, str(channel)))
+        raise NotImplementedError(
+            "This method doesn't know how to locate "
+            "DMT-Omega files for {}".format(str(channel)))
     if base is None:
         base = os.path.join(os.sep, 'gds-{}'.format(ifo.lower()), 'dmt',
                             'triggers', tag, '{0}')


### PR DESCRIPTION
This PR does two things

- separates the finder methods for KleineWelle and DMT-Omega. There's a lot of overlap, but each method is now much simpler, and easier to maintain
- updated the file-naming convention for DMT-Omega files so that the finder works again