### PR TITLE
Updated to use lal.utils.CacheEntry

### DIFF
--- a/trigfind/core.py
+++ b/trigfind/core.py
@@ -27,7 +27,9 @@ import re
 import datetime
 import warnings
 
-from glue.lal import (Cache, CacheEntry)
+from lal.utils import CacheEntry
+
+from glue.lal import Cache
 from glue.segments import segment as Segment
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'


### PR DESCRIPTION
This PR modifies `trigfind.core` to use `lal.utils.CacheEntry` instead of `glue.lal.CacheEntry`, since that was deprecated as of 1.57.0.