### PR TITLE
Updated to not depend on lalsuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,11 @@ before_install:
   - pip install --quiet --upgrade pip setuptools
 
 install:
-  - pip install --quiet coveralls "pytest>=2.8" unittest2 mock lalsuite
+  - |
+    pip install --quiet \
+        coveralls \
+        "pytest>=2.8" \
+        "mock ; python_version < '3'"
   - pip install -r requirements.txt
   - pip install --editable .
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A utility to find GW trigger files produced by event trigger generators and archived on the LIGO Data Grid.
 
-[![Build Status](https://travis-ci.org/gwpy/gwtrigfind.svg?branch=master)](https://travis-ci.org/gwpy/gwtrigfind)
+[![Build Status](https://travis-ci.com/gwpy/gwtrigfind.svg?branch=master)](https://travis-ci.org/gwpy/gwtrigfind)
 [![Coverage Status](https://coveralls.io/repos/github/gwpy/gwtrigfind/badge.svg?branch=master)](https://coveralls.io/github/gwpy/gwtrigfind?branch=master)
 
 ## Quickstart for python

--- a/gwtrigfind/test_trigfind.py
+++ b/gwtrigfind/test_trigfind.py
@@ -36,11 +36,6 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 # -- mock methods -------------------------------------------------------------
 
-def realpath(f):
-    return f
-
-os.path.realpath = realpath  # mock realpath for testing
-
 
 def mock_iglob_factory(fileformat):
     def mock_gps_glob(globstr):
@@ -63,13 +58,6 @@ def mock_iglob_factory(fileformat):
             t += d
             yield f
     return mock_gps_glob
-
-
-def mock_find_detchar_glob(globstr):
-    if globstr.lower().endswith('_omicron'):
-        return True
-    else:
-        return list(glob.iglob(globstr))
 
 
 # -- tests --------------------------------------------------------------------
@@ -152,9 +140,8 @@ def test_find_kleinewelle_files():
 
 def test_find_detchar_files():
     iglob = mock_iglob_factory('L1-GDS_CALIB_STRAIN_OMICRON-{0}-{1}.xml')
-    glob_ = mock_find_detchar_glob
     with mock.patch('glob.iglob', iglob):
-        with mock.patch('glob.glob', glob_):
+        with mock.patch('glob.glob', bool):
             cache = core.find_detchar_files(
                 'L1:GDS-CALIB_STRAIN', 1135641617, 1135728017,
                 etg='omicron')

--- a/gwtrigfind/test_trigfind.py
+++ b/gwtrigfind/test_trigfind.py
@@ -103,8 +103,8 @@ def test_find_trigger_files():
         cache = core.find_trigger_files(
             'L1:GDS-CALIB_STRAIN', 'dmt-omega', 1135641617, 1135728017)
         assert len(cache) == 9
-        assert cache[0].path == (
-            '/gds-l1/dmt/triggers/L-HOFT_Omega/11356/'
+        assert cache[0] == (
+            'file:///gds-l1/dmt/triggers/L-HOFT_Omega/11356/'
             'L1-OMEGA_TRIGGERS_DOWNSELECT-1135640000-10000.xml')
 
 
@@ -114,8 +114,8 @@ def test_find_dmt_omega_files():
         cache = core.find_dmt_omega_files(
             'L1:GDS-CALIB_STRAIN', 1135641617, 1135728017)
         assert len(cache) == 9
-        assert cache[0].path == (
-            '/gds-l1/dmt/triggers/L-HOFT_Omega/11356/'
+        assert cache[0] == (
+            'file:///gds-l1/dmt/triggers/L-HOFT_Omega/11356/'
             'L1-OMEGA_TRIGGERS_DOWNSELECT-1135640000-10000.xml')
         # check wrapper method works
         assert cache == core.find_trigger_files(
@@ -132,8 +132,8 @@ def test_find_kleinewelle_files():
         cache = core.find_kleinewelle_files(
             'L1:TEST-CHANNEL', 1135641617, 1135728017)
         assert len(cache) == 9
-        assert cache[0].path == (
-            '/gds-l1/dmt/triggers/L-KW_TRIGGERS/L-KW_TRIGGERS-11356/'
+        assert cache[0] == (
+            'file:///gds-l1/dmt/triggers/L-KW_TRIGGERS/L-KW_TRIGGERS-11356/'
             'L-KW_TRIGGERS-1135640000-10000.xml')
         # check wrapper method works
         assert cache == core.find_trigger_files(
@@ -145,8 +145,8 @@ def test_find_kleinewelle_files():
         cache = core.find_kleinewelle_files(
             'L1:GDS-CALIB_STRAIN', 1135641617, 1135728017)
         assert len(cache) == 9
-        assert cache[0].path == (
-            '/gds-l1/dmt/triggers/L-KW_HOFT/'
+        assert cache[0] == (
+            'file:///gds-l1/dmt/triggers/L-KW_HOFT/'
             'L-KW_HOFT-11356/L-KW_HOFT-1135640000-10000.xml')
 
 
@@ -159,15 +159,15 @@ def test_find_detchar_files():
                 'L1:GDS-CALIB_STRAIN', 1135641617, 1135728017,
                 etg='omicron')
             assert len(cache) == 9
-            assert cache[0].path == (
-                '/home/detchar/triggers/*/L1/GDS-CALIB_STRAIN_Omicron/'
+            assert cache[0] == (
+                'file:///home/detchar/triggers/*/L1/GDS-CALIB_STRAIN_Omicron/'
                 '11356/L1-GDS_CALIB_STRAIN_OMICRON-1135640000-10000.xml')
             cache2 = core.find_detchar_files(
                 'L1:GDS-CALIB_STRAIN', 1146873617, 1146873617+1,
                 etg='omicron')
-            assert cache2[0].path == (
-                '/home/detchar/triggers/L1/GDS_CALIB_STRAIN_OMICRON/11468/'
-                'L1-GDS_CALIB_STRAIN_OMICRON-1146870000-10000.xml')
+            assert cache2[0] == (
+                'file:///home/detchar/triggers/L1/GDS_CALIB_STRAIN_OMICRON/'
+                '11468/L1-GDS_CALIB_STRAIN_OMICRON-1146870000-10000.xml')
 
             # check wrapper method works
             assert cache == core.find_trigger_files(
@@ -212,8 +212,8 @@ def test_find_omega_online_files():
         cache = core.find_omega_online_files(
             'G1:DER_DATA_H', 1135641617, 1135728017)
         assert len(cache) == 9
-        assert cache[0].path == (
-            '/home/omega/online/G1_DER_DATA_H/segments/11356/*/'
+        assert cache[0] == (
+            'file:///home/omega/online/G1_DER_DATA_H/segments/11356/*/'
             'G1-OMEGA_TRIGGERS_DOWNSELECT-1135640000-10000.txt')
 
         # check wrapper method works

--- a/gwtrigfind/test_trigfind.py
+++ b/gwtrigfind/test_trigfind.py
@@ -195,18 +195,21 @@ def test_find_pycbc_live_files():
             None, 'pycbc-live', 1126259140, 1126269148)
 
 
-@mock.patch(OPEN, mock_open(read_data="""
+def test_find_daily_cbc_files():
+    # mock the reader, and make sure we get the right cache
+    with mock.patch(OPEN, mock_open(read_data="""
 H1 INSPIRAL 0 50 /test/H1-INSPIRAL-0-50.xml.gz
 H1 INSPIRAL 50 50 /test/H1-INSPIRAL-50-50.xml.gz
 H1 INSPIRAL 100 50 /test/H1-INSPIRAL-100-50.xml.gz
-"""[1:]))
-def test_find_daily_cbc_files():
-    # can't do much without faking the entire thing
-    cache = core.find_daily_cbc_files('L1:GDS-CALIB_STRAIN', 0, 100)
+"""[1:])):
+        cache = core.find_daily_cbc_files('L1:GDS-CALIB_STRAIN', 0, 100)
+        assert cache == core.find_trigger_files(
+            'L1:GDS-CALIB_STRAIN', 'daily-cbc', 0, 100)
     assert len(cache) == 2
     assert cache[0] == 'file:///test/H1-INSPIRAL-0-50.xml.gz'
-    assert cache == core.find_trigger_files(
-        'L1:GDS-CALIB_STRAIN', 'daily-cbc', 0, 100)
+
+    # without mock, check that we just get an empty cache
+    assert not core.find_daily_cbc_files('X1:GDS-CALIB_STRAIN', 0, 100)
 
 
 def test_find_omega_online_files():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-python-dateutil
+astropy
 ligo-segments >= 1.0.0
-lalsuite

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ scripts = glob.glob(os.path.join('bin', '*'))
 
 # declare dependencies
 setup_requires = ['setuptools']
-install_requires = ['python-dateutil', 'ligo-segments', 'lalsuite']
+install_requires = ['astropy', 'ligo-segments']
 tests_require = ['pytest']
 if {'pytest', 'test'}.intersection(sys.argv):
     setup_requires.append('pytest_runner')


### PR DESCRIPTION
This PR updates `gwtrigfind` to not depend on `lal` as follows

- use `astropy.time` for time conversion
- return basic `str` URLs instead of `CacheEntry`

This is a backwards-incompatible change.