### PR TITLE
Change default file extension for omicron trigger files to HDF5 files

### DIFF
--- a/gwtrigfind/core.py
+++ b/gwtrigfind/core.py
@@ -132,7 +132,7 @@ def find_trigger_urls(*args, **kwargs):
     return find_trigger_files(*args, **kwargs)
 
 
-def find_detchar_files(channel, start, end, etg='omicron', ext='xml.gz'):
+def find_detchar_files(channel, start, end, etg='omicron', ext='h5'):
     """Find files in the detchar home directory following T1300468
 
     Parameters
@@ -151,7 +151,7 @@ def find_detchar_files(channel, start, end, etg='omicron', ext='xml.gz'):
         ``'omicron'``
 
     ext : `str`, optional
-        file extension, defaults to ``'xml.gz'``
+        file extension, defaults to ``'h5'``
 
     Returns
     -------


### PR DESCRIPTION
Omicron will soon only output ROOT and HDF5 files (with extension `h5`). Current versions output these and `xml.gz` files, but moving forward we should default to the HDF5 file format.

Note that internally, the Omicron HDF5 file does not have `bandwidth` or `duration`, for example. These can be derived from the `fstart` and `fend` or `tstart` and `tend` parameters respectively.