### PR TITLE
Compiled re should use a raw string with escape sequences

### DIFF
--- a/gwtrigfind/core.py
+++ b/gwtrigfind/core.py
@@ -39,11 +39,11 @@ from ligo.segments import segment as Segment
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-daily_cbc = re.compile('\Adaily[\s_-]cbc\Z')
-pycbc_live = re.compile('\Apycbc[\s_-]live\Z')
-kleinewelle = re.compile('\A(kw|kleinewelle)\Z', re.I)
-dmt_omega = re.compile('\Admt([\s_-])?omega\Z', re.I)
-omega = re.compile('\Aomega([\s_-])?(online)?\Z', re.I)
+daily_cbc = re.compile(r'\Adaily[\s_-]cbc\Z')
+pycbc_live = re.compile(r'\Apycbc[\s_-]live\Z')
+kleinewelle = re.compile(r'\A(kw|kleinewelle)\Z', re.I)
+dmt_omega = re.compile(r'\Admt([\s_-])?omega\Z', re.I)
+omega = re.compile(r'\Aomega([\s_-])?(online)?\Z', re.I)
 channel_delim = re.compile('[:_-]')
 
 OMICRON_O2_EPOCH = 1146873617


### PR DESCRIPTION
This PR makes the use of raw strings for compiled regexp. When first running `gwtrigfind`, I found the warning:
```
/home/evan.goetz/lscrepos/gwtrigfind-eg/gwtrigfind/core.py:42: SyntaxWarning: invalid escape sequence '\A'
  daily_cbc = re.compile('\Adaily[\s_-]cbc\Z')
/home/evan.goetz/lscrepos/gwtrigfind-eg/gwtrigfind/core.py:43: SyntaxWarning: invalid escape sequence '\A'
  pycbc_live = re.compile('\Apycbc[\s_-]live\Z')
/home/evan.goetz/lscrepos/gwtrigfind-eg/gwtrigfind/core.py:44: SyntaxWarning: invalid escape sequence '\A'
  kleinewelle = re.compile('\A(kw|kleinewelle)\Z', re.I)
/home/evan.goetz/lscrepos/gwtrigfind-eg/gwtrigfind/core.py:45: SyntaxWarning: invalid escape sequence '\A'
  dmt_omega = re.compile('\Admt([\s_-])?omega\Z', re.I)
/home/evan.goetz/lscrepos/gwtrigfind-eg/gwtrigfind/core.py:46: SyntaxWarning: invalid escape sequence '\A'
  omega = re.compile('\Aomega([\s_-])?(online)?\Z', re.I)
```
Interestingly, running a second time causes the warning to go away, so one doesn't notice this the first time the code is run.

According to `re`,
> If you’re not using a raw string to express the pattern, remember that Python also uses the backslash as an escape sequence in string literals; if the escape sequence isn’t recognized by Python’s parser, the backslash and subsequent character are included in the resulting string. However, if Python would recognize the resulting sequence, the backslash should be repeated twice. This is complicated and hard to understand, so it’s highly recommended that you use raw strings for all but the simplest expressions.

This PR changes the compiled regexp code into raw strings so that this warning is fixed.